### PR TITLE
Check !mounted rather than context==null

### DIFF
--- a/lib/keyboard_avoider.dart
+++ b/lib/keyboard_avoider.dart
@@ -139,7 +139,7 @@ class _KeyboardAvoiderState extends State<KeyboardAvoider> with WidgetsBindingOb
   }
 
   void _resize() {
-    if (context == null) {
+    if (!mounted) {
       return;
     }
 


### PR DESCRIPTION
A pull request to your pull request ;-)

In Flutter 2, it's necessary to replace the `context==null` check with `!mounted` since `context` is non-nullable.